### PR TITLE
Describe a partial mapping to DC

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,25 @@ The tests will make sure the record is valid, so focus on things the computer do
 Is the description readable?
 If this is a new contributor, spot check the original source for accuracy.
 If a new enumeration value is proposed, consider getting more opinions before approving.
+
+## Relationship to other metadata standards
+
+The Privacy Deployments Registry can be partially mapped to [Dublin Core](https://www.dublincore.org/specifications/dublin-core/dcmi-terms/).
+
+| Registry | DC |
+|---|---|
+| | contributor |
+| | coverage |
+| data_curator | creator |
+| publication_date | date |
+| data_product_description | description |
+| | format |
+| | identifier |
+| | language |
+| | publisher |
+| | relation |
+| | rights |
+| | source |
+| dp_flavor.data_domain | subject |
+| short_name | title |
+| | type |


### PR DESCRIPTION
- Fix #25 

Assumes the schema in 
- #18

Merge it first!

I think this highlights a couple gaps:

- `coverage`: Would it make sense to add optional fields for the geographic and temporal coverage?
- `publisher`: Should there be some indication of whether the DP release itself is public? The publisher, if any, might not be distinct from the curator, but if people actually want to look at DP data, could we flag those cases?
- `short_name`: Can't remember why it needs to be `short`?
- `relation`: Does it make sense to think of the DP deployment as something distinct from any write-ups that may describe it? For some cases, the DP release itself may not be public, and the paper stands in for it, while in others, there may be something which really is the release, and papers about the release are ancillary.
