### PR TITLE
URLs: yes link check, no spell check

### DIFF
--- a/dictionary.txt
+++ b/dictionary.txt
@@ -4,3 +4,4 @@ COVID
 ε_sym
 ε_norm
 dataset
+URL

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ pre-commit
 black
 pyspellchecker
 pip-tools
+requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,12 @@ black==25.1.0
     # via -r requirements.in
 build==1.2.2.post1
     # via pip-tools
+certifi==2025.6.15
+    # via requests
 cfgv==3.4.0
     # via pre-commit
+charset-normalizer==3.4.2
+    # via requests
 click==8.2.1
     # via
     #   black
@@ -29,7 +33,9 @@ fqdn==1.5.1
 identify==2.6.12
     # via pre-commit
 idna==3.10
-    # via jsonschema
+    # via
+    #   jsonschema
+    #   requests
 iniconfig==2.1.0
     # via pytest
 isoduration==20.11.0
@@ -81,6 +87,8 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
+requests==2.32.4
+    # via -r requirements.in
 rfc3339-validator==0.1.4
     # via jsonschema
 rfc3987==1.3.8
@@ -99,6 +107,8 @@ typing-extensions==4.14.0
     # via referencing
 uri-template==1.3.0
     # via jsonschema
+urllib3==2.5.0
+    # via requests
 virtualenv==20.31.2
     # via pre-commit
 webcolors==24.11.1

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -47,6 +47,7 @@ def check_spelling(yaml_path):
     for path, text in pairs:
         if not isinstance(text, str):
             continue
+        text = re.sub(r"https?://\S+", "", text)
         words = re.findall(r"\w+", text)
         for word in words:
             lc_word = word.lower()
@@ -62,8 +63,8 @@ def check(yaml_path: Path):
     ]
     errors = {}
     for detail_check in detail_checks:
-        name = detail_check.__name__
-        print(f"\t{name.replace('_', ' ')}...")
+        name = detail_check.__name__.replace("_", " ")
+        print(f"\t{name}...")
         error = detail_check(yaml_path)
         if error:
             errors[name] = error

--- a/tests/good_deployments/google_tier_1.yaml
+++ b/tests/good_deployments/google_tier_1.yaml
@@ -7,7 +7,9 @@ deployment:
   data_curator: Google
   intended_use: To help researchers, public health experts, and data analysts better understand the impact of COVID-19 via population-level symptom search trends
   data_product_type: Summary statistics
-  data_product_description: A publicly released dataset of daily or weekly time series giving the relative frequency of searches for ~400 predefined symptoms in each geographic region, normalized by total search activity
+  data_product_description: >
+    A publicly released dataset of daily or weekly time series giving the relative frequency of searches for ~400 predefined symptoms in each geographic region, normalized by total search activity
+    This line is just to exercise URL handling: https://example.com/intenshunal-mispeling
   publication_date: "2020-09-01"
 
   # Tier 2?:

--- a/tests/good_deployments/google_tier_1.yaml
+++ b/tests/good_deployments/google_tier_1.yaml
@@ -9,7 +9,7 @@ deployment:
   data_product_type: Summary statistics
   data_product_description: >
     A publicly released dataset of daily or weekly time series giving the relative frequency of searches for ~400 predefined symptoms in each geographic region, normalized by total search activity
-    This line is just to exercise URL handling: https://example.com/intenshunal-mispeling
+    This line is just to exercise URL handling: https://opendp.org/
   publication_date: "2020-09-01"
 
   # Tier 2?:

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -32,6 +32,6 @@ def test_good_yaml(yaml_path):
 def test_bad_yaml(bad_yaml_path):
     errors = check(bad_yaml_path)
     clean_error = (
-        re.sub(r"\W+", " ", errors["check_schema"][0]).strip().replace(" ", "_").lower()
+        re.sub(r"\W+", " ", errors["check schema"][0]).strip().replace(" ", "_").lower()
     )
     assert clean_error == bad_yaml_path.stem


### PR DESCRIPTION
- Fix #35 
- Fix #11

Down the road, I'd suggest that the URL link checking not be run on every commit, but instead be a cron job. When this is mature, if some URL referenced by an old deployment stops working, it shouldn't block new commits... but for now, this is fine, and we probably do want to know if any site that is being referenced is flaky.

The expression to pull URLs out of the string might also need to be tweaked, but this is enough to get started.