### PR TITLE
use latex on one exaple record

### DIFF
--- a/deployments/google_covid_19_sympton_search.yaml
+++ b/deployments/google_covid_19_sympton_search.yaml
@@ -18,7 +18,7 @@ deployment:
     privacy_unit_description: '“user-day”, with contribution bounding. A single privacy unit is all of one user’s searches on one day. Before adding noise, each user’s day is bounded so that they can contribute at most: 1 count per symptom and at most 3 symptom counts in total, plus at most 1 normalization count (one per day).'
     privacy_parameters:
       epsilon: 1.68
-    privacy_parameters_description: 'Symptom counts: ε_sym = 1.638 + Normalization counts: ε_norm = 0.042'
+    privacy_parameters_description: 'Symptom counts: \\(\epsilon_{sym}\\) = 1.638 + Normalization counts: \\(\epsilon_{norm}\\) = 0.042'
   model:
     model_type: Central
     model_type_description: 'A trusted Google curator applies the Laplace mechanism via Google’s open-source DP library before any data release.'


### PR DESCRIPTION
Double back-ticks needed because this is first processed as markdown.
- Fix #44

Without the full setup, it's hard for authors in this repo to confirm that this is doing the right thing.
- Down the road? #32