### PR TITLE
Small privacyunit edits

### DIFF
--- a/deployments/covid19_search_trends_symptoms.yaml
+++ b/deployments/covid19_search_trends_symptoms.yaml
@@ -24,7 +24,7 @@ deployment:
     unprotected_quantities: The paper mentions that, for each day and geographic granularity level, a user’s contribution is capped to three counts in total, and that this was justified by the observation that approximately 75% of users search at most three symptoms per day. There was no mention of the aforementioned statistic being computed under differential privacy.
 
   privacy_loss:
-    privacy_unit: User-day
+    privacy_unit: User-day-level
     privacy_unit_description: |
       The mechanism protects "every user's symptom search activity on a particular day". Adjacent datasets are those that differ by the addition or removal of one user's contribution for a single day.
       The function that computes the distance between any two datasets in the data domain is the symmetric distance, and the maximum distance between any two datasets in the data domain is one.

--- a/deployments/google_mobility.yaml
+++ b/deployments/google_mobility.yaml
@@ -27,7 +27,7 @@ deployment:
     unprotected_quantities: No unprotected quantities mentioned.
 
   privacy_loss:
-    privacy_unit: User-day
+    privacy_unit: User-day-level
     privacy_unit_description: Adjacent datasets are obtained by adding or removing a single user’s data in a single day. The function that computes the distance between any two datasets in the data domain is the symmetric distance, and the maximum distance between any two datasets in the data domain is one.
     privacy_parameters:
       epsilon: 2.64

--- a/deployments/mobility_trends_hurricane.yaml
+++ b/deployments/mobility_trends_hurricane.yaml
@@ -9,7 +9,7 @@ deployment:
   data_curator: Spectus
   intended_use: Mobility Catastrophe Data
   data_product_type: Summary statistics
-  data_product_region: United States
+  data_product_region: USA
   description: Evacuation metrics for residents of Harris County, Texas during 2017 hurricane.
   publication_date: '2022-01-01'
   dp_flavor:

--- a/deployments/recurve_energy_dp.yaml
+++ b/deployments/recurve_energy_dp.yaml
@@ -7,7 +7,7 @@ deployment:
   data_curator: Recurve
   intended_use: Measure the impact of OhmConnect's demand response program on electricity usage, while protecting customer privacy.
   data_product_type: Summary statistics
-  data_product_region: California, United States
+  data_product_region: California, USA
   description: |
     Aggregate summary statistics describing how much energy OhmConnect participants saved during a demand response event (during the August 14, 2020 California Blackout), relative to a matched, non-participant group. Specifically, the statistics are:
       - Average Load Shape: A private, hour-by-hour profile of the comparison group's average 'observed' and 'predicted' energy consumption over a 24-hour period.

--- a/deployments/recurve_energy_dp.yaml
+++ b/deployments/recurve_energy_dp.yaml
@@ -28,7 +28,7 @@ deployment:
       - The number of customers in the comparison group N = 4948 is public.
 
   privacy_loss:
-    privacy_unit: user-level
+    privacy_unit: User-level
     privacy_unit_description: Adjacent datasets differ by one customer's data in MCE's residential customer base. The function that computes the distance between any two datasets in the data domain is the symmetric distance, and the maximum distance between any two datasets in the data domain is 1.
     privacy_parameters:
       epsilon: 4.72

--- a/deployments/synth_data_public_use.yaml
+++ b/deployments/synth_data_public_use.yaml
@@ -8,7 +8,7 @@ deployment:
   data_curator: Office of National Statistics UK
   intended_use: Synthetic data
   data_product_type: Synthetic data
-  data_product_region: United States
+  data_product_region: USA
   description: We recommend the use of generative adversarial networks
     (GANs) possibly in conjunction with privacy-preserving mechanisms such as differential
     privacy.

--- a/deployments/wikimedia_current_usage_data.yaml
+++ b/deployments/wikimedia_current_usage_data.yaml
@@ -28,7 +28,7 @@ deployment:
         - The suppression threshold (\\(\tau\\)=90) where noisy counts below 90 are removed from the final output.
 
   privacy_loss:
-    privacy_unit: Device-day
+    privacy_unit: Device-day-level
     privacy_unit_description: Adjacent datasets are those that differ by the data of a single device for a single day. Each device’s contribution is capped at a maximum of 10 unique pageviews per day. Since the implementation makes it impossible to link devices to users, the paper acknowledges that a user could visit the same page from multiple devices, and that 'this behavior could potentially be observed in the output data'. The function that computes the distance between any two datasets in the data domain is the symmetric distance, and the maximum distance between any two datasets in the data domain is one.
     privacy_parameters:
       rho: 0.015


### PR DESCRIPTION
Small edits (capitalization & "level" suffix) for privacy unit consistency.
Small location edits ("United States" to "USA")