### PR TITLE
fix latex typos

### DIFF
--- a/deployments/birth_dataset.yaml
+++ b/deployments/birth_dataset.yaml
@@ -22,10 +22,10 @@ deployment:
     privacy_parameters:
       epsilon: 9.98
     privacy_parameters_description: |
-      "The privacy loss budget was allocated as follow: \\(\epsilon = 4)\\ for fitting the generative model;
-      \\(\epsilon = 0.99)\\ for evaluating of the dataset with a list of predefined of acceptance criteria;
+      "The privacy loss budget was allocated as follow: \\(\epsilon = 4\\) for fitting the generative model;
+      \\(\epsilon = 0.99\\) for evaluating of the dataset with a list of predefined of acceptance criteria;
       and a factor 2 is applied due to the private selection process. Therefore, the overall privacy loss budget
-      is \\(\epsilon = 9.98)\\."
+      is \\(\epsilon = 9.98\\)."
   model:
     model_name: Central
     # model_name_description: TODO

--- a/deployments/county_business_patterns.yaml
+++ b/deployments/county_business_patterns.yaml
@@ -1,4 +1,4 @@
-url_slug: census-county-business-patterns-united-states-census-bureau-2023
+url_slug: census-county-business-patterns-u-s-census-bureau-2023
 status: Converted
 registry_authors:
 - Nicolas Berrios

--- a/deployments/mobility_trends_hurricane.yaml
+++ b/deployments/mobility_trends_hurricane.yaml
@@ -22,8 +22,8 @@ deployment:
     privacy_parameters:
       epsilon: 10.0
     privacy_parameters_description: |
-      "In this case, the Laplace mechanism is used for all four operations. Finally, the privacy budget, \\(\epsilon)\\,
-      is set as follows: • \\(\epsilon = 4)\\ for CTU • \\(\epsilon = 2)\\ for CE • \\(\epsilon = 1)\\ for CED • \\(\epsilon = 3)\\ for SD."
+      "In this case, the Laplace mechanism is used for all four operations. Finally, the privacy budget, \\(\epsilon\\),
+      is set as follows: • \\(\epsilon = 4\\) for CTU • \\(\epsilon = 2\\) for CE • \\(\epsilon = 1\\) for CED • \\(\epsilon = 3\\) for SD."
   model:
     model_name: Central
     # model_name_description: TODO

--- a/deployments/shared_mobility_dataset.yaml
+++ b/deployments/shared_mobility_dataset.yaml
@@ -20,15 +20,15 @@ deployment:
     privacy_unit: User-trip-level
     privacy_unit_description: |
       '"This dataset contains trip flow information from over 300 million people world-wide (including residents and visitors of cities)
-      for the year 2016, aggregated weekly and with spatial granularity corresponding to S2 cells of approximately 1.27 km\\(^2)\\. ...
+      for the year 2016, aggregated weekly and with spatial granularity corresponding to S2 cells of approximately 1.27 km\\(^2\\). ...
       All trips were anonymized and aggregated by jointly applying differential privacy via the Laplace mechanism in combination with k-anonymity."'
     privacy_parameters:
       epsilon: 0.66
       delta: 2.1e-29
     privacy_parameters_description: |
       '"The automated Laplace mechanism adds random noise drawn
-      from a zero mean Laplace distribution and yields (\\(\epsilon, \delta)\\)-differential privacy guarantee
-      of \\(\epsilon = 0.66)\\ and \\(\delta = 2.1 × 10−29)\\, which is very strong."'
+      from a zero mean Laplace distribution and yields (\\(\epsilon, \delta\\))-differential privacy guarantee
+      of \\(\epsilon = 0.66\\) and \\(\delta = 2.1 × 10−29\\), which is very strong."'
   model:
     model_name: Central
     # model_name_description: TODO

--- a/deployments/telemetry_collection_windows.yaml
+++ b/deployments/telemetry_collection_windows.yaml
@@ -23,7 +23,7 @@ deployment:
       epsilon: 1.672
     privacy_parameters_description: |
       '"By Theorem 5, in deployment, a single round of data collection across an arbitrary large number of apps satisfies
-      \\(epsilon \dprime)\\-DP, where \\(epsilon \dprime)\\ = 1.672."'
+      \\(epsilon \dprime\\)-DP, where \\(epsilon \dprime\\) = 1.672."'
   model:
     model_name: Local
     # model_name_description: TODO

--- a/deployments/user_url_privacy.yaml
+++ b/deployments/user_url_privacy.yaml
@@ -28,12 +28,12 @@ deployment:
       epsilon: 1.453
       delta: 1.0e-05
       rho: 0.0728
-    privacy_parameters_description:
-      - '"At \\(\delta = 10−5)\\, the \\(\epsilon_{user})\\ for each individual action type decreases from about 0.45 (as reported
+    privacy_parameters_description: |
+      "At \\(\delta = 10−5\\), the \\(\epsilon_{user}\\) for each individual action type decreases from about 0.45 (as reported
       in an earlier section) to a range between 0.34 and 0.35. The total user-level privacy consumption across all action types under
-      \\(\mu)\\-GDP is about 0.376. The total user-level privacy consumption across all action types reduces from an epsilon of 1.844
-      (reported in an earlier section) to about 1.453. To reiterate, the privacy consumption under \\(\rho)\\-zCDP is unchanged:
-      \\(\rho_{user})\\ remains at 0.0052 for each individual action column and remains at 0.0728 across the entire dataset."'
+      \\(\mu\\)-GDP is about 0.376. The total user-level privacy consumption across all action types reduces from an epsilon of 1.844
+      (reported in an earlier section) to about 1.453. To reiterate, the privacy consumption under \\(\rho\\)-zCDP is unchanged:
+      \\(\rho_{user}\\) remains at 0.0052 for each individual action column and remains at 0.0728 across the entire dataset."
   model:
     model_name: Central
     # model_name_description: TODO

--- a/deployments/vaccine_search_insights.yaml
+++ b/deployments/vaccine_search_insights.yaml
@@ -23,8 +23,8 @@ deployment:
       delta: 1.0e-05
     privacy_parameters_description: |
       "The applied anonymization techniques protect every user’s
-      daily search activity related to COVID-19 vaccinations with (\\{\epsilon, \delta)\\)-diﬀerential
-      privacy for \\(\epsilon)\\ = 2.19 and \\(\delta)\\ = 10−5."
+      daily search activity related to COVID-19 vaccinations with (\\(\epsilon, \delta\\))-diﬀerential
+      privacy for \\(\epsilon\\) = 2.19 and \\(\delta\\) = 10−5."
   model:
     model_name: Central
     # model_name_description: TODO

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -90,7 +90,9 @@ def check_latex_escapes(yaml_path):
     errors = []
     for path, text in pairs:
         if isinstance(text, str) and (match := re.search(r"\\\\[^()]", text)):
-            errors.append(f'{path} contains "{match.group(0)}"')
+            errors.append(
+                f'{path} contains "{text[match.start() - 4:match.end() + 4]}"'
+            )
     return errors
 
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -84,6 +84,16 @@ def check_quoting(yaml_path):
     return errors
 
 
+def check_latex_escapes(yaml_path):
+    deployment = load(yaml_path.open(), Loader=Loader)
+    pairs = get_all_values_paths(deployment)
+    errors = []
+    for path, text in pairs:
+        if isinstance(text, str) and (match := re.search(r"\\\\[^()]", text)):
+            errors.append(f'{path} contains "{match.group(0)}"')
+    return errors
+
+
 checks = {name for name in globals().keys() if name.startswith("check_")}
 
 

--- a/scripts/update_slug.py
+++ b/scripts/update_slug.py
@@ -12,7 +12,7 @@ def make_slug(data):
     return "_".join(
         [
             clean(deployment["name"]),
-            clean(deployment["data_curator"]),
+            clean("-".join(deployment["data_curators"])),
             clean(deployment["publication_date"].split("-")[0]),
         ]
     ).replace("_", "-")


### PR DESCRIPTION
- Fix #107 (though double escaping wasn't actually the problem)

This is a good argument for just using unicode, if you can. It also resurfaces the idea of getting some preview of how it will be rendered, but with the complexity involved, I feel like the best option there is just to have the jekyll site running locally, which is not a satisfying answer.