### PR TITLE
split `evidence source` on delims

### DIFF
--- a/known_bad_urls.txt
+++ b/known_bad_urls.txt
@@ -10,3 +10,6 @@ https://journalprivacyconfidentiality.org/index.php/jpc/article/view/722/684
 https://doi.org/10.1145/3177732.3177733
 https://medium.com/uber-security-privacy/uber-open-source-differential-privacy-57f31e85c57a
 https://analytics.wikimedia.org/published/datasets/country_project_page_historical/00_README.html
+
+http://example.com/peer-reviewed
+http://example.com/blog

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -108,10 +108,13 @@ def check_evidence_sources(yaml_path):
 
     errors = []
     for path, text in source_pairs:
-        if text not in evidence_sources_keys:
-            errors.append(
-                f"In {path}, '{text}' is not one of {list(evidence_sources_keys)}"
-            )
+        full_sources = [source.strip() for source in text.split(";")]
+        for full_source in full_sources:
+            source_key = full_source.split(",")[0].strip()
+            if source_key not in evidence_sources_keys:
+                errors.append(
+                    f"In {path}, '{source_key}' is not one of {list(evidence_sources_keys)}"
+                )
 
     return errors
 

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -109,7 +109,9 @@ def check_evidence_sources(yaml_path):
     errors = []
     for path, text in source_pairs:
         if text not in evidence_sources_keys:
-            errors.append(f"{path} should be one of {evidence_sources_keys}")
+            errors.append(
+                f"In {path}, '{text}' is not one of {list(evidence_sources_keys)}"
+            )
 
     return errors
 

--- a/tests/good_deployments/template.yaml
+++ b/tests/good_deployments/template.yaml
@@ -75,7 +75,7 @@ deployment:
     pre_processing_eda_hyperparameter_tuning: '' # Tier 3
     mechanisms_source: 'example'
     mechanisms: '' # Tier 3
-    justification_source: 'example'
+    justification_source: 'example, p. 42; example_2, free text note'
     justification: '' # Tier 3
 
   administrative:

--- a/tests/good_deployments/template.yaml
+++ b/tests/good_deployments/template.yaml
@@ -82,9 +82,13 @@ deployment:
     sources: '' # white papers
     evidence_sources:
       example:
-        url: 'http://example.com' # Fill in correct value
-        title: 'Example' # Fill in correct value
+        url: 'http://example.com/peer-reviewed' # Fill in correct value
+        title: 'Peer-reviewed' # Fill in correct value
         base: 'Peer-reviewed publication'
+      example_2:
+        url: 'http://example.com/blog' # Fill in correct value
+        title: 'Blog' # Fill in correct value
+        base: 'Other public source'
     notes: '' # other extra information
     registry_authors:
       - '' # Fill in correct value.


### PR DESCRIPTION
While it would usually be better to make everthing explicit in the schema, I favor this approach for a few reasons.
- Since there are so many `_source` fields, we want to keep the data entry burden low: We don't want to require a nested data structure on every one of these.
- In many cases, for example if the single source is a url which doesn't point to a PDF, all the references will be the same key: Simple things should be simple.
- When there are multiple sources, delimiting with `;` and `,` is still easy to read and parse, either by a human or a machine.