### PR TITLE
Require source tags to be globally unique

### DIFF
--- a/deployments/apple_iconic_scenes_photo_selections_2023.yaml
+++ b/deployments/apple_iconic_scenes_photo_selections_2023.yaml
@@ -47,7 +47,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      apple_2023:
+      apple_iconic:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Learning Iconic Scenes with Differential Privacy

--- a/deployments/apple_popular_emojis.yaml
+++ b/deployments/apple_popular_emojis.yaml
@@ -73,7 +73,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      apple:
+      apple_emoji:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Learning with Privacy at Scale

--- a/deployments/broadband_coverage.yaml
+++ b/deployments/broadband_coverage.yaml
@@ -76,13 +76,13 @@ deployment:
       - A Monte Carlo simulation process to estimate the error introduced by DP was chosen, the rationale being that this empirical method is better for estimating the combined error from several private sources and does not result in additional privacy losses.
   administrative:
     evidence_sources:
-      paper:
+      broadband_paper:
         citation:
           title: 'U.S. Broadband Coverage Data Set: A Differentially Private Data Release'
           url: https://arxiv.org/abs/2103.14035
           year: 2021
           author: Mayana Pereira, Allen Kim, Joshua Allen, Kevin White, Juan Lavista Ferres, Rahul Dodhia
-      github:
+      broadband_github:
         citation:
           title: United States Broadband Usage Percentages Dataset
           url: https://github.com/microsoft/USBroadbandUsagePercentages

--- a/deployments/census_demographic_and_housing.yaml
+++ b/deployments/census_demographic_and_housing.yaml
@@ -97,30 +97,30 @@ deployment:
 
   administrative:
     evidence_sources:
-      dhc:
+      census_dhc:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 2020 Census Demographic and Housing Characteristics File (DHC) Technical Documentation
           url: https://www2.census.gov/programs-surveys/decennial/2020/technical-documentation/complete-tech-docs/demographic-and-housing-characteristics-file-and-demographic-profile/2020census-demographic-and-housing-characteristics-file-and-demographic-profile-techdoc.pdf
           author: U.S. Census Bureau
-      press_release:
+      census_press_release:
         evidence_source_type: Formal publication by the deploying organization # TODO: Would a different type be better?
         citation:
           title: Census Bureau Releases New 2020 Census Data on Age, Sex, Race, Hispanic Origin, Households and Housing
           url: https://www.census.gov/newsroom/press-releases/2023/2020-census-demographic-profile-and-dhc.html
           year: 2023
           month: May
-      guidance:
+      census_guidance:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure Avoidance for DHC and Guidance for Data Users
           url: https://www2.census.gov/library/publications/decennial/2020/census-briefs/c2020br-08.pdf
-      handbook:
+      census_handbook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure avoidance handbook for the 2020 Census
           url: https://www2.census.gov/library/publications/decennial/2020/2020-census-disclosure-avoidance-handbook.pdf
-      algorithm:
+      census_algorithm:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: The 2020 Census Disclosure Avoidance System TopDown Algorithm

--- a/deployments/census_detailed_demographic_and_housing_a.yaml
+++ b/deployments/census_detailed_demographic_and_housing_a.yaml
@@ -81,22 +81,22 @@ deployment:
 
   administrative:
     evidence_sources:
-      dhc:
+      census_a_dhc:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 2020 Census Detailed Demographic and Housing Characteristics File A (Detailed DHC-A) Technical Documentation
           url: https://www2.census.gov/programs-surveys/decennial/2020/technical-documentation/complete-tech-docs/detailed-demographic-and-housing-characteristics-file-a/2020census-detailed-dhc-a-techdoc.pdf
-      press_release:
+      census_a_press_release:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Census Bureau Announces Release Date for 2020 Census Data Product on Race and Ethnicity
           url: https://www.census.gov/newsroom/press-releases/2023/2020-census-detailed-dhc-a.html
-      methods:
+      census_a_methods:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Disclosure Avoidance Methods for the Detailed Demographic and Housing Characteristics File A (Detailed DHC-A): How SafeTab-P Works'
           url: https://www2.census.gov/library/publications/decennial/2020/census-briefs/c2020br-05.pdf
-      handbook:
+      census_a_handbook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure avoidance handbook for the 2020 Census

--- a/deployments/census_detailed_demographic_and_housing_b.yaml
+++ b/deployments/census_detailed_demographic_and_housing_b.yaml
@@ -81,22 +81,22 @@ deployment:
 
   administrative:
     evidence_sources:
-      dhc:
+      census_b_dhc:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 2020 Census Detailed Demographic and Housing Characteristics File B (Detailed DHC-B) Technical Documentation
           url: https://www2.census.gov/programs-surveys/decennial/2020/technical-documentation/complete-tech-docs/detailed-demographic-and-housing-characteristics-file-b/2020census-detailed-dhc-b-techdoc.pdf
-      press_release:
+      census_b_press_release:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Census Bureau to Hold Webinar on Release of 2020 Census Detailed Demographic and Housing Characteristics File B
           url: https://www.census.gov/newsroom/press-releases/2024/webinar-2020-census-detailed-dhc-b.html
-      safetab:
+      census_b_safetab:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Disclosure Avoidance and the 2020 Census: How SafeTab-H Works'
           url: https://www2.census.gov/library/publications/decennial/2020/census-briefs/c2020br-11.pdf
-      handbook:
+      census_b_handbook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure avoidance handbook for the 2020 Census

--- a/deployments/census_redistricting_data.yaml
+++ b/deployments/census_redistricting_data.yaml
@@ -96,12 +96,12 @@ deployment:
 
   administrative:
     evidence_sources:
-      handbook:
+      census_redistricting_handbook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure avoidance handbook for the 2020 Census
           url: https://www2.census.gov/library/publications/decennial/2020/2020-census-disclosure-avoidance-handbook.pdf
-      algorithm:
+      census_redistricting_algorithm:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: The 2020 Census Disclosure Avoidance System TopDown Algorithm

--- a/deployments/census_supplemental_demographic_and_housing.yaml
+++ b/deployments/census_supplemental_demographic_and_housing.yaml
@@ -71,23 +71,22 @@ deployment:
 
   administrative:
     evidence_sources:
-      dhc:
+      census_supplemental_dhc:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 2020 Supplemental Demographic and Housing Characteristics File (S-DHC) Technical Documentation
           url: https://www2.census.gov/programs-surveys/decennial/2020/technical-documentation/complete-tech-docs/supplemental-demographic-and-housing-characteristics-file/2020census-supplemental-dhc-techdoc.pdf
-      press_release:
+      census_supplemental_press_release:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Census Bureau Releases Final 2020 Census Data Product
           url: https://www.census.gov/newsroom/press-releases/2024/final-2020-census-data-product-s-dhc.html
-
-      how_it_works:
+      census_supplemental_how_it_works:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Disclosure Avoidance and the Supplemental Demographic and Housing Characteristics File (S-DHC): How PHSafe Works'
           url: https://www2.census.gov/library/publications/decennial/2020/census-briefs/c2020br-12.pdf
-      handbook:
+      census_supplemental_handbook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Disclosure avoidance handbook for the 2020 Census

--- a/deployments/covid19_search_trends_symptoms.yaml
+++ b/deployments/covid19_search_trends_symptoms.yaml
@@ -81,14 +81,14 @@ deployment:
 
   administrative:
     evidence_sources:
-      documentation:
+      convid19_documentation:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: COVID-19 Search Trends symptoms dataset
           url: https://storage.googleapis.com/gcp-public-data-symptom-search/COVID-19%20Search%20Trends%20symptoms%20dataset%20documentation%20.pdf
           year: 2021
           month: 2
-      paper:
+      convid19_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Google COVID-19 Search Trends Symptoms Dataset: Anonymization Process Description (version 1.0)'
@@ -102,7 +102,7 @@ deployment:
           year: 2020
           month: September
           url: https://arxiv.org/pdf/2009.01265
-      data_product:
+      convid19_data_product:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: COVID-19 Search Trends symptoms dataset

--- a/deployments/employment_outcomes.yaml
+++ b/deployments/employment_outcomes.yaml
@@ -42,7 +42,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      paper:
+      employment_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           url: https://journalprivacyconfidentiality.org/index.php/jpc/article/view/722/684
@@ -52,7 +52,7 @@ deployment:
           volume: 9
           number: 2
           year: 2019
-      documentation:
+      employment_documentation:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           url: https://lehd.ces.census.gov/data/pseo_documentation.html

--- a/deployments/google_mobility.yaml
+++ b/deployments/google_mobility.yaml
@@ -91,7 +91,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      paper:
+      mobility_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Google COVID-19 Community Mobility Reports: Anonymization Process Description (version 1.1)'

--- a/deployments/healthkit.yaml
+++ b/deployments/healthkit.yaml
@@ -37,13 +37,13 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      healthkit_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Learning with Privacy at Scale
           url: https://docs-assets.developer.apple.com/ml-research/papers/learning-with-privacy-at-scale.pdf
           author: Differential Privacy Team, Apple
-      additional:
+      healthkit_additional:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Learning with Privacy at Scale

--- a/deployments/korean_statistics_datahub.yaml
+++ b/deployments/korean_statistics_datahub.yaml
@@ -30,7 +30,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      datahub_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           url: https://unstats.un.org/wiki/display/UGTTOPPT/11.+Statistics+Korea%3A+Developing+a+privacy-preserving+Statistical+Data+Hub+Platform

--- a/deployments/linkedin_hiring_reports.yaml
+++ b/deployments/linkedin_hiring_reports.yaml
@@ -39,7 +39,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      linkedin_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: A Members First Approach to Enabling LinkedIn's Labor Market Insights at Scale

--- a/deployments/lookup_hints.yaml
+++ b/deployments/lookup_hints.yaml
@@ -37,7 +37,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      hints_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Differential Privacy

--- a/deployments/microsoft_ctdc_victim_perpertartor_synthetic_dataset_2023.yaml
+++ b/deployments/microsoft_ctdc_victim_perpertartor_synthetic_dataset_2023.yaml
@@ -72,26 +72,26 @@ deployment:
 
   administrative:
     evidence_sources:
-      blog:
+      ctdc_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: IOM and Microsoft release first-ever differentially private synthetic dataset to counter human trafficking
           url: https://www.microsoft.com/en-us/research/blog/iom-and-microsoft-release-first-ever-differentially-private-synthetic-dataset-to-counter-human-trafficking/
           year: 2022
           month: December
-      dataset:
+      ctdc_dataset:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: The Global Victim-Perpetrator Synthetic Dataset
           url: https://www.ctdatacollaborative.org/global-victim-perpetrator-synthetic-dataset
-      codebook:
+      ctdc_codebook:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Counter Trafficking Data Collaborative (CTDC): The Global Victim-Perpetrator Synthetic Data Codebook'
           url: https://www.ctdatacollaborative.org/sites/g/files/tmzbdl2011/files/2023-07/CTDCsyntheic_victim-perpetrator_codebook_v1.pdf
           year: 2022
           month: December
-      sourcecode:
+      ctdc_sourcecode:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Synthetic data showcase

--- a/deployments/movement_ranges_maps.yaml
+++ b/deployments/movement_ranges_maps.yaml
@@ -32,7 +32,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      blog:
+      movement_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Protecting privacy in Facebook mobility data during the COVID-19 response
@@ -40,7 +40,7 @@ deployment:
           author: Amaç Herdağdelen, Alex Dow, Bogdan State, Payman Mohassel, Alex Pompe
           year: 2020
           month: June
-      data:
+      movement_data:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Movement Range Maps

--- a/deployments/on_device_browser_rec.yaml
+++ b/deployments/on_device_browser_rec.yaml
@@ -29,7 +29,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      on_device_rec_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Using Federated Learning to Improve Brave’s On-Device Recommendations While Protecting Your Privacy

--- a/deployments/recurve_energy_dp.yaml
+++ b/deployments/recurve_energy_dp.yaml
@@ -98,22 +98,22 @@ deployment:
 
   administrative:
     evidence_sources:
-      paper:
+      recurve_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Applying Energy Differential Privacy To Enable Measurement of the OhmConnect Virtual Power Plant
           url: https://assets.website-files.com/5cb0a177570549b5f11b9550/5ffddb83b5ea5d67f5c43661_Quantifying%20The%20OhmConnect%20Virtual%20Power%20Plant%20During%20the%20California%20Blackouts.pdf
-      blog:
+      recurve_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Revenue-Grade Analysis of the OhmConnect Virtual Power Plant During the California Blackouts
           url: https://www.recurve.com/blog/revenue-grade-analysis-of-the-ohmconnect-virtual-power-plant-during-the-california-blackouts
-      intro_paper:
+      recurve_intro_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Differential Privacy for Expanding Access to Building Energy Data
           url: https://edp.recurve.com/uploads/8/6/5/0/8650231/aceee_paper_final.pdf
-      correction_blog:
+      recurve_correction_blog:
         evidence_source_type: Other public source
         citation:
           title: A list of real-world uses of differential privacy

--- a/deployments/safari_energy_drain.yaml
+++ b/deployments/safari_energy_drain.yaml
@@ -52,7 +52,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      paper:
+      safari_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Learning with Privacy at Scale

--- a/deployments/safety_classifier.yaml
+++ b/deployments/safety_classifier.yaml
@@ -38,7 +38,7 @@ deployment:
   #   justification:
   administrative:
     evidence_sources:
-      blog:
+      safety_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Protecting users with differentially private synthetic training data
@@ -46,7 +46,7 @@ deployment:
           author: Alexey Kurakin, and Natalia Ponomareva
           year: 2024
           month: May
-      paper:
+      safety_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Harnessing large-language models to generate private synthetic text

--- a/deployments/shared_mobility_dataset.yaml
+++ b/deployments/shared_mobility_dataset.yaml
@@ -38,7 +38,7 @@ deployment:
     justification: '"All trips were anonymized and aggregated by jointly applying differential privacy via the Laplace mechanism in combination with k-anonymity."'
   administrative:
     evidence_sources:
-      paper:
+      hierarchical_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Hierarchical organization of urban mobility and its connection with city livability

--- a/deployments/spanish_language_next_word.yaml
+++ b/deployments/spanish_language_next_word.yaml
@@ -63,7 +63,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      blog:
+      spanish_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Federated Learning with Formal Differential Privacy Guarantees
@@ -71,7 +71,7 @@ deployment:
           author: Brendan McMahan and Abhradeep Thakurta
           year: 2022
           month: February
-      paper:
+      spanish_paper:
         # Paper that introduces the DP variant of Follow-The-Regularized-Leader (DP-FTRL) used in the deployment
         evidence_source_type: Formal publication by the deploying organization
         citation:

--- a/deployments/synth_data_public_use.yaml
+++ b/deployments/synth_data_public_use.yaml
@@ -30,7 +30,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      gans_paper:
         citation:
           title: Generative adversarial networks (GANs) for synthetic dataset generation with binary classes
           url: https://datasciencecampus.ons.gov.uk/projects/generative-adversarial-networks-gans-for-synthetic-dataset-generation-with-binary-classes/

--- a/deployments/telemetry_collection_windows.yaml
+++ b/deployments/telemetry_collection_windows.yaml
@@ -34,7 +34,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      telemetry_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Collecting Telemetry Data Privately

--- a/deployments/uber.yaml
+++ b/deployments/uber.yaml
@@ -68,7 +68,7 @@ deployment:
       - Formal proof that elastic sensitivity is an upper bound of local sensistivity is presented.
   administrative:
     evidence_sources:
-      paper:
+      uber_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Towards Practical Differential Privacy for SQL Queries
@@ -76,7 +76,7 @@ deployment:
           author: Noah Johnson, Joseph P. Near, Dawn Song
           journal: Proceedings of the VLDB Endowment
           volume: 11
-      blog:
+      uber_blog:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Updates to Uber’s Open Source Project for Differential Privacy
@@ -84,7 +84,7 @@ deployment:
           author: Menotti Minutillo
           year: 2018
           month: January
-      source:
+      uber_source:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: sql-differential-privacy

--- a/deployments/vaccine_search_insights.yaml
+++ b/deployments/vaccine_search_insights.yaml
@@ -35,7 +35,7 @@ deployment:
     justification: '' # TODO: Fill in correct value
   administrative:
     evidence_sources:
-      paper:
+      vaccine_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: 'Google COVID-19 Vaccination Search Insights: Anonymization Process Description'

--- a/deployments/wikimedia_current_usage_data.yaml
+++ b/deployments/wikimedia_current_usage_data.yaml
@@ -66,7 +66,7 @@ deployment:
 
   administrative:
     evidence_sources:
-      paper:
+      wikimedia_paper:
         evidence_source_type: Formal publication by the deploying organization
         citation:
           title: Publishing Wikipedia usage data with strong privacy guarantees

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -99,7 +99,7 @@ def check_latex_escapes(yaml_path):
 checks = {name for name in globals().keys() if name.startswith("check_")}
 
 
-def check(yaml_path: Path, only=checks):
+def check_local(yaml_path: Path, only=checks):
     detail_checks = [
         function
         for name, function in globals().items()
@@ -113,6 +113,23 @@ def check(yaml_path: Path, only=checks):
         assert isinstance(error, list), f"Expected list, not {error}"
         if error:
             errors[name] = error
+    return errors
+
+
+def check_global(yaml_paths: list[Path]):
+    errors = {}
+    evidence_source_keys = set()
+    for yaml_path in yaml_paths:
+        deployment = load(yaml_path.open(), Loader=Loader)
+        new_keys = set(
+            deployment["deployment"]["administrative"]["evidence_sources"].keys()
+        )
+
+        if intersection := new_keys & evidence_source_keys:
+            errors[
+                yaml_path.name
+            ] = f"Keys not globally unique: {', '.join(intersection)}"
+        evidence_source_keys |= new_keys
     return errors
 
 
@@ -149,12 +166,20 @@ if __name__ == "__main__":
         print("No files selected")
         exit(1)
     errors = {}
+
+    global_error = check_global(yaml_paths)
+    if global_error:
+        errors["global"] = global_error
+
     for yaml_path in yaml_paths:
         print(f"Validating {yaml_path.name}...")
-        error = check(yaml_path, only=args.only or (checks - set(args.skip)))
-        assert isinstance(error, dict), f"Expected list, not {error}"
-        if error:
-            errors[yaml_path.name] = error
+        local_error = check_local(
+            yaml_path, only=args.only or (checks - set(args.skip))
+        )
+        assert isinstance(local_error, dict), f"Expected dict, not {local_error}"
+        if local_error:
+            errors[yaml_path.name] = local_error
+
     if errors:
         print(dump(errors))
         exit(1)

--- a/tests/test_yaml.py
+++ b/tests/test_yaml.py
@@ -1,4 +1,4 @@
-from check import check, checks
+from check import check_local, checks
 from update_slug import update_slug
 
 import pytest
@@ -30,7 +30,7 @@ def test_updated_slugs(yaml_path):
     "yaml_path", root.glob("deployments/*.yaml"), ids=lambda path: path.name
 )
 def test_real_yaml(yaml_path):
-    errors = check(yaml_path, only=checks - {"check_urls"})
+    errors = check_local(yaml_path, only=checks - {"check_urls"})
     assert not errors
 
 
@@ -38,7 +38,7 @@ def test_real_yaml(yaml_path):
     "yaml_path", root.glob("tests/good_deployments/*.yaml"), ids=lambda path: path.name
 )
 def test_good_yaml(yaml_path):
-    errors = check(yaml_path)
+    errors = check_local(yaml_path)
     assert not errors
 
 
@@ -48,7 +48,7 @@ def test_good_yaml(yaml_path):
     ids=lambda path: path.name,
 )
 def test_bad_yaml(bad_yaml_path):
-    errors = check(bad_yaml_path)
+    errors = check_local(bad_yaml_path)
     assert errors, "Expected errors, but there aren't any"
     errors_stem = errors_to_stem(errors)
     assert errors_stem == bad_yaml_path.stem, errors


### PR DESCRIPTION
Thinking about how this will be used downstream in the UI, we're probably going to want anchor links from the field to the citation information. It makes the UI code a little simpler if it can assume these strings are unique, but this is not the only way it could work!

I guess I'm bringing it up now, because once we start filling in the citations on every field, if we later decide we do need global uniqueness, it will be a little more work to correct everything after the fact.