### PR TITLE
Add details fields (for citations)

### DIFF
--- a/schemas/deployments-schema.yaml
+++ b/schemas/deployments-schema.yaml
@@ -60,6 +60,7 @@ properties:
                   - Nonprofit
                   # Add to this list as needed.
             minItems: 1
+          data_curators_details: {type: string, tier: 3, description: "Can be used to provide citation."}
           description:
             tier: 1
             description: Brief description of the data product.
@@ -82,6 +83,7 @@ properties:
               - Interactive API
               - SQL queries
               # Add to this list as needed.
+          data_product_type_details: {type: string, tier: 3, description: "Can be used to provide citation."}
           data_product_region:
             tier: 1
             description: Free text. What region does the data describe, and/or, what region's laws apply to this data product.
@@ -98,6 +100,7 @@ properties:
               - Energy
               - Finance
               # Add to this list as needed.
+          data_product_sector_details: {type: string, tier: 3, description: "Can be used to provide citation."}
           publication_date:
             tier: 1
             description: When the data product was published, in YYYY-MM-DD format. Day and month can be set to "01" if unknown. In cases of many releases, the publication date can be expressed as the date of first publication.
@@ -105,6 +108,7 @@ properties:
               The publication **date** refers to when the data product was published or otherwise created. In cases of data products that are created under continual release, the date listed is the date of first publication.
             type: string
             format: date
+          publication_date_details: {type: string, tier: 3, description: "Can be used to provide citation."}
       # Tiers 2 and 3
       dp_variant:
         type: object
@@ -130,6 +134,7 @@ properties:
               - Zero-concentrated DP
               - Renyi DP
               - Custom
+          variant_name_details: {type: string, tier: 3, description: "Can be used to provide citation."}
           data_domain:
             tier: 3
             description: Actual, potential, or counterfactual datasets eligible for protection.
@@ -165,6 +170,7 @@ properties:
               Number of privacy units (e.g., number of users, households, sets of all events associated with individual users in a day).
               In cases where the dataset size is not public, an approximate number should be reported here.
             type: integer
+          number_of_privacy_units_details: {type: string, tier: 3, description: "Can be used to provide citation."}
           privacy_parameters:
             tier: 2
             description: Intensity of protection, as characterized by values set for parameters like epsilon, delta, or rho. Which parameters are specified will vary according to the DP variant.

--- a/tests/good_deployments/template.yaml
+++ b/tests/good_deployments/template.yaml
@@ -7,16 +7,21 @@ deployment:
       -
         data_curator_name: 'U.S. Census Bureau' # Fill in correct value.
         data_curator_type: 'Government' # Fill in correct value.
+    data_curators_details: ''
     description: ''
     intended_use: ''
     data_product_type: 'Summary statistics' # Fill in correct value.
+    data_product_type_details: ''
     data_product_region: ''
     data_product_sector: 'Technology' # Fill in correct value.
+    data_product_sector_details: ''
     publication_date: '1900-01-01' # Fill in correct value.
+    publication_date_details: ''
 
   # Tiers 2 and 3:
   dp_variant:
     variant_name: Pure DP # Fill in correct value.
+    variant_name_details: ''
     data_domain: '' # Tier 3
     unprotected_quantities: '' # Tier 3
 
@@ -24,6 +29,7 @@ deployment:
     privacy_unit: ''
     privacy_unit_details: ''
     number_of_privacy_units: 1
+    number_of_privacy_units_details: ''
     privacy_parameters: # Fill in correct value, and remove others
       epsilon: 1.0
       delta: 1.0e-10

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -85,6 +85,12 @@ def test_node_has_details_long(path, node):
         "/deployment/administrative/notes",
         "/deployment/administrative/registry_authors",
         "/deployment/administrative/status",
+        "/deployment/basic/data_curators_details",
+        "/deployment/basic/data_product_type_details",
+        "/deployment/basic/data_product_sector_details",
+        "/deployment/basic/publication_date_details",
+        "/deployment/dp_variant/variant_name_details",
+        "/deployment/privacy_loss/number_of_privacy_units_details",
     ]
     if path in skip_list:
         assert "description_long" not in node.keys()


### PR DESCRIPTION
I believe that every field which is not free text or administrative now has an accompanying `_details` field. This is similar to earlier work (#172), except that that PR paired every existing field with a new field. This PR has a smaller scope.

